### PR TITLE
Fix for focus jumping to top of image when option selected on mobile

### DIFF
--- a/less/gmcq.less
+++ b/less/gmcq.less
@@ -114,7 +114,7 @@
 
     .gmcq-item input {
         position:absolute;
-        top:14px;
+        bottom:14px;
         left:25px;
         .dir-rtl & {
             left:inherit;


### PR DESCRIPTION
Moved input component next to option representation