### PR TITLE
explicitly specifying to use 'gmcq.hbs'

### DIFF
--- a/js/adapt-contrib-gmcq.js
+++ b/js/adapt-contrib-gmcq.js
@@ -80,6 +80,8 @@ define(function(require) {
 
         }
 
+    }, {
+        template: 'gmcq'
     });
 
     Adapt.register("gmcq", Gmcq);


### PR DESCRIPTION
Fixes #86 