### PR TITLE
Disabled classes on revisit

### DIFF
--- a/templates/gmcq.hbs
+++ b/templates/gmcq.hbs
@@ -2,7 +2,7 @@
     {{> component this}}
     <div class="gmcq-widget component-widget clearfix {{#unless _isEnabled}} disabled {{#if _isInteractionComplete}} complete submitted show-user-answer {{#if _isCorrect}}correct{{/if}} {{/if}} {{/unless}}">
         {{#each _items}}
-        <div class="gmcq-item component-item {{#unless ../_isEnabled}} {{#if _isCorrect}}correct{{else}}incorrect{{/if}} {{/unless}} item-{{@index}} {{odd @index}}">
+        <div class="gmcq-item component-item {{#unless ../_isEnabled}} disabled {{#if _isCorrect}}correct{{else}}incorrect{{/if}} {{/unless}} item-{{@index}} {{odd @index}}">
             <input type="checkbox" id="{{../_id}}-{{@index}}" aria-labelledby="{{../_id}}-{{@index}}-aria"/>
             <label id="{{../_id}}-{{@index}}-aria" for="{{../_id}}-{{@index}}" class="component-item-color component-item-text-color component-item-border {{#if _isSelected}}selected{{/if}}">
 

--- a/templates/gmcq.hbs
+++ b/templates/gmcq.hbs
@@ -2,8 +2,8 @@
     {{> component this}}
     <div class="gmcq-widget component-widget clearfix {{#unless _isEnabled}} disabled {{#if _isInteractionComplete}} complete submitted show-user-answer {{#if _isCorrect}}correct{{/if}} {{/if}} {{/unless}}">
         {{#each _items}}
-        <div class="gmcq-item component-item {{#unless ../_isEnabled}} disabled {{#if _isCorrect}}correct{{else}}incorrect{{/if}} {{/unless}} item-{{@index}} {{odd @index}}">
-            <input type="checkbox" id="{{../_id}}-{{@index}}" aria-labelledby="{{../_id}}-{{@index}}-aria"/>
+        <div class="gmcq-item component-item {{#unless ../_isEnabled}} {{#if _isCorrect}}correct{{else}}incorrect{{/if}} {{/unless}} item-{{@index}} {{odd @index}}">
+            <input type="checkbox" id="{{../_id}}-{{@index}}" aria-labelledby="{{../_id}}-{{@index}}-aria"{{#unless ../_isEnabled}} disabled{{/unless}}/>
             <label id="{{../_id}}-{{@index}}-aria" for="{{../_id}}-{{@index}}" class="{{#unless ../_isEnabled}}disabled {{/unless}} component-item-color component-item-text-color component-item-border {{#if _isSelected}}selected{{/if}}">
 
                 <img src="{{_graphic.src}}" alt="{{_graphic.alt}}" data-large="{{_graphic.large}}" data-small="{{_graphic.small}}"/>

--- a/templates/gmcq.hbs
+++ b/templates/gmcq.hbs
@@ -4,7 +4,7 @@
         {{#each _items}}
         <div class="gmcq-item component-item {{#unless ../_isEnabled}} disabled {{#if _isCorrect}}correct{{else}}incorrect{{/if}} {{/unless}} item-{{@index}} {{odd @index}}">
             <input type="checkbox" id="{{../_id}}-{{@index}}" aria-labelledby="{{../_id}}-{{@index}}-aria"/>
-            <label id="{{../_id}}-{{@index}}-aria" for="{{../_id}}-{{@index}}" class="component-item-color component-item-text-color component-item-border {{#if _isSelected}}selected{{/if}}">
+            <label id="{{../_id}}-{{@index}}-aria" for="{{../_id}}-{{@index}}" class="{{#unless ../_isEnabled}}disabled {{/unless}} component-item-color component-item-text-color component-item-border {{#if _isSelected}}selected{{/if}}">
 
                 <img src="{{_graphic.src}}" alt="{{_graphic.alt}}" data-large="{{_graphic.large}}" data-small="{{_graphic.small}}"/>
 


### PR DESCRIPTION
After completing a GMCQ, a class of `disabled` is added to each of the `<label>` elements.
When going back to the menu and then returning to the GMCQ, the classes haven't been added.