### PR TITLE
Enhancement/894 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ guide the learner’s interaction with the component.
 
 **_recordInteraction** (boolean) Determines whether or not the learner's answers will be recorded to the LMS via cmi.interactions. Default is `true`. For further information, see the entry for `_shouldRecordInteractions` in the README for [adapt-contrib-spoor](https://github.com/adaptlearning/adapt-contrib-spoor).
 
+**_columns** (number): Defines the number of columns wide the **_items** are displayed in. If the value of **_numberOfColumns** is `2`, each **_items** will be 50% wide. Similarly, if the value of **_numberOfColumns** is `3`, each **_items** will be 33.3% wide. In mobile view, the width of each **_items** is 100%.
+
 **_items** (array): Each *item* represents one choice for the multiple choice question and contains values for **_graphic**, **text**, and **_shouldBeSelected**.  
 
 >**text** (string): Optional text that is displayed as part of the multiple choice option.  
@@ -104,7 +106,7 @@ label is not a visible element. It is utilized by assistive technology such as s
 No known limitations.   
 
 ----------------------------
-**Version number:**  2.0.2   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Version number:**  2.0.3   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
 **Framework versions:** 2.0  
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-gmcq/graphs/contributors)  
 **Accessibility support:** WAI AA   

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-gmcq",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "framework": "^2.0.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-gmcq",
   "issues": "https://adaptlearning.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10100&issuetype=1&priority=6&components=10508",

--- a/example.json
+++ b/example.json
@@ -12,6 +12,7 @@
     "_selectable":1,
     "_canShowModelAnswer": true,
     "_recordInteraction":true,
+    "_columns": 3,
     "title": "GMCQ",
     "displayTitle": "GMCQ",
     "body": "Which of the following options would you consider to be correct?",

--- a/js/adapt-contrib-gmcq.js
+++ b/js/adapt-contrib-gmcq.js
@@ -25,6 +25,18 @@ define(function(require) {
             return events;
 
         },
+        
+        setUpColumns: function() {
+            var columns = this.model.get('_columns');
+
+            if (!columns) return;
+
+            this.$el.addClass('gmcq-column-layout');
+
+            if (Adapt.device.screenSize === 'large') {
+                this.$('.gmcq-item').css('width', (100 / columns) + '%');
+            }
+        },
 
         onItemSelected: function(event) {
 

--- a/js/adapt-contrib-gmcq.js
+++ b/js/adapt-contrib-gmcq.js
@@ -67,11 +67,17 @@ define(function(require) {
         onQuestionRendered: function() {
 
             this.resizeImage(Adapt.device.screenSize);
+            this.listenTo(Adapt, 'device:resize', this.onScreenSizeChanged);
+            this.setUpColumns();
 
             this.$('label').imageready(_.bind(function() {
                 this.setReadyStatus();
             }, this));
 
+        },
+        
+        onScreenSizeChanged: function() {
+            this.setUpColumns();
         },
 
         resizeImage: function(width) {

--- a/js/adapt-contrib-gmcq.js
+++ b/js/adapt-contrib-gmcq.js
@@ -25,20 +25,6 @@ define(function(require) {
             return events;
 
         },
-        
-        setUpColumns: function() {
-            var columns = this.model.get('_columns');
-
-            if (!columns) return;
-
-            if (Adapt.device.screenSize === 'large') {
-                this.$el.addClass('gmcq-column-layout');
-                this.$('.gmcq-item').css('width', (100 / columns) + '%');
-            } else {
-                this.$el.removeClass('gmcq-column-layout');
-                this.$('.gmcq-item').css('width', '');
-            }
-        },
 
         onItemSelected: function(event) {
 
@@ -62,14 +48,16 @@ define(function(require) {
 
             this.restoreUserAnswers();
 
-            this.listenTo(Adapt, 'device:changed', this.resizeImage);
+            this.listenTo(Adapt, {
+                'device:changed': this.resizeImage,
+                'device:resize': this.onDeviceResize
+            });
 
         },
 
         onQuestionRendered: function() {
 
             this.resizeImage(Adapt.device.screenSize);
-            this.listenTo(Adapt, 'device:resize', this.onScreenSizeChanged);
             this.setUpColumns();
 
             this.$('label').imageready(_.bind(function() {
@@ -78,7 +66,7 @@ define(function(require) {
 
         },
         
-        onScreenSizeChanged: function() {
+        onDeviceResize: function() {
             this.setUpColumns();
         },
 
@@ -91,6 +79,20 @@ define(function(require) {
                 $(this).find('img').attr('src', src);
             });
 
+        },
+
+        setUpColumns: function() {
+            var columns = this.model.get('_columns');
+
+            if (!columns) return;
+
+            if (Adapt.device.screenSize === 'large') {
+                this.$el.addClass('gmcq-column-layout');
+                this.$('.gmcq-item').css('width', (100 / columns) + '%');
+            } else {
+                this.$el.removeClass('gmcq-column-layout');
+                this.$('.gmcq-item').css('width', '');
+            }
         },
 
         // hack for IE8

--- a/js/adapt-contrib-gmcq.js
+++ b/js/adapt-contrib-gmcq.js
@@ -31,10 +31,12 @@ define(function(require) {
 
             if (!columns) return;
 
-            this.$el.addClass('gmcq-column-layout');
-
             if (Adapt.device.screenSize === 'large') {
+                this.$el.addClass('gmcq-column-layout');
                 this.$('.gmcq-item').css('width', (100 / columns) + '%');
+            } else {
+                this.$el.removeClass('gmcq-column-layout');
+                this.$('.gmcq-item').css('width', '');
             }
         },
 

--- a/less/gmcq.less
+++ b/less/gmcq.less
@@ -23,10 +23,6 @@
                     .dir-rtl & {
                         margin: 2.5%;
                     }
-
-                    @media (max-width: @device-width-medium) {
-                        margin: 0;
-                    }
                 }
             }
         }

--- a/less/gmcq.less
+++ b/less/gmcq.less
@@ -1,6 +1,7 @@
 .gmcq-component {
     &.gmcq-column-layout {
         .gmcq-widget {
+            // Font size set to 0 so there's no gap between items
             font-size: 0;
             text-align: center;
         }

--- a/less/gmcq.less
+++ b/less/gmcq.less
@@ -1,44 +1,44 @@
 .gmcq-component {
     &.gmcq-column-layout {
-		.gmcq-widget {
-			font-size: 0;
-			text-align: center;
-		}
+        .gmcq-widget {
+            font-size: 0;
+            text-align: center;
+        }
 
-		.gmcq-item {
-			display: inline-block;
-			float: none;
-			vertical-align: top;
+        .gmcq-item {
+            display: inline-block;
+            float: none;
+            vertical-align: top;
 
-			.dir-rtl & {
-				float: none;
-			}
+            .dir-rtl & {
+                float: none;
+            }
 
-			&.even,
-			&.odd {
-				label {
-					margin: 2.5%;
+            &.even,
+            &.odd {
+                label {
+                    margin: 2.5%;
 
-					.dir-rtl & {
-						margin: 2.5%;
-					}
+                    .dir-rtl & {
+                        margin: 2.5%;
+                    }
 
-					@media (max-width: @device-width-medium) {
-						margin: 0;
-					}
-				}
-			}
-		}
+                    @media (max-width: @device-width-medium) {
+                        margin: 0;
+                    }
+                }
+            }
+        }
 
-		.gmcq-item-inner {
-			font-size: @body-text-font-size;
-			text-align: left;
+        .gmcq-item-inner {
+            font-size: @body-text-font-size;
+            text-align: left;
 
-			.dir-rtl & {
-				text-align: right;
-			}
-		}
-	}
+            .dir-rtl & {
+                text-align: right;
+            }
+        }
+    }
 	
     .gmcq-item {
         position: relative;

--- a/less/gmcq.less
+++ b/less/gmcq.less
@@ -1,5 +1,45 @@
 .gmcq-component {
+    &.gmcq-column-layout {
+		.gmcq-widget {
+			font-size: 0;
+			text-align: center;
+		}
 
+		.gmcq-item {
+			display: inline-block;
+			float: none;
+			vertical-align: top;
+
+			.dir-rtl & {
+				float: none;
+			}
+
+			&.even,
+			&.odd {
+				label {
+					margin: 2.5%;
+
+					.dir-rtl & {
+						margin: 2.5%;
+					}
+
+					@media (max-width: @device-width-medium) {
+						margin: 0;
+					}
+				}
+			}
+		}
+
+		.gmcq-item-inner {
+			font-size: @body-text-font-size;
+			text-align: left;
+
+			.dir-rtl & {
+				text-align: right;
+			}
+		}
+	}
+	
     .gmcq-item {
         position: relative;
         width: 50%;

--- a/properties.schema
+++ b/properties.schema
@@ -73,6 +73,15 @@
       "validators": [],
       "help": "If set to 'true', the user's answer(s) will be recorded to cmi.interactions on the LMS (where supported)."
     },
+    "_columns": {
+      "type": "number",
+      "required": false,
+      "default": 0,
+      "title": "Columns",
+      "inputType": "Number",
+      "validators": ["number"],
+      "help": "Set the number of columns. If value is '0', component uses the default layout."
+    },
     "_selectable": {
       "type":"number",
       "required":true,


### PR DESCRIPTION
Added a new attribute to the GMCQ component called '_columns' which defines the number of columns wide the items are displayed in. 

If the attribute is not present or the value is set to 0 then the component uses the default styling. If the value is set to 1 or more then the component will automatically divine 100% by the number of columns to work out the width of each item. 

For example; if '_columns' is set to 3 and the component has 5 items, each item will be 33.3% wide and the 2 overflow items will be centrally aligned on a second row.

The attribute is not required in the properties.schema so Authoring Tool users are not affected when updating components. The new styling is attributed to a class which is only added if '_columns' is present and value is not 0 which should therefore not affect any previously styled courses.

Issue - https://github.com/adaptlearning/adapt_framework/issues/894