### PR TITLE
Hook into _canShowMarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ guide the learner’s interaction with the component.
 
 **_canShowModelAnswer** (boolean): Setting this to `false` prevents the [**_showCorrectAnswer** button](https://github.com/adaptlearning/adapt_framework/wiki/Core-Buttons) from being displayed. The default is `true`.
 
+**_canShowMarking** (boolean): Setting this to `false` prevents ticks and crosses being displayed on question completion. The default is `true`.
+
 **_recordInteraction** (boolean) Determines whether or not the learner's answers will be recorded to the LMS via cmi.interactions. Default is `true`. For further information, see the entry for `_shouldRecordInteractions` in the README for [adapt-contrib-spoor](https://github.com/adaptlearning/adapt-contrib-spoor).
 
 **_columns** (number): Defines the number of columns wide the **_items** are displayed in. If the value of **_numberOfColumns** is `2`, each **_items** will be 50% wide. Similarly, if the value of **_numberOfColumns** is `3`, each **_items** will be 33.3% wide. In mobile view, the width of each **_items** is 100%.

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-gmcq",
   "version": "2.0.4",
-  "framework": "^2.0.0",
+  "framework": "^2.0.11",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-gmcq",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-gmcq%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",
   "displayName" : "Graphical Multiple Choice Question",

--- a/example.json
+++ b/example.json
@@ -11,6 +11,7 @@
     "_isRandom":false,
     "_selectable":1,
     "_canShowModelAnswer": true,
+    "_canShowMarking": true,
     "_recordInteraction":true,
     "_columns": 3,
     "title": "GMCQ",

--- a/less/gmcq.less
+++ b/less/gmcq.less
@@ -210,7 +210,8 @@
             .gmcq-item-icon {
                 display: none;
             }
-            .selected .gmcq-correct-icon {
+            .incorrect .selected .gmcq-correct-icon,
+            .correct .selected .gmcq-correct-icon {
                 display: block;
             }
         }

--- a/properties.schema
+++ b/properties.schema
@@ -129,6 +129,14 @@
       "validators": [],
       "help": "Select 'true' to allow the user to view feedback on their answer"
     },
+    "_canShowMarking": {
+      "type": "boolean",
+      "default": true,
+      "title": "Display Marking",
+      "inputType": { "type": "Boolean", "options": [ true, false ] },
+      "validators": [],
+      "help": "Select 'true' to display ticks and crosses on question completion"
+    },
     "_shouldDisplayAttempts": {
       "type":"boolean",
       "required":false,

--- a/templates/gmcq.hbs
+++ b/templates/gmcq.hbs
@@ -2,7 +2,7 @@
     {{> component this}}
     <div class="gmcq-widget component-widget clearfix {{#unless _isEnabled}} disabled {{#if _isInteractionComplete}} complete submitted show-user-answer {{#if _isCorrect}}correct{{/if}} {{/if}} {{/unless}}">
         {{#each _items}}
-        <div class="gmcq-item component-item {{#unless ../_isEnabled}} {{#if _isCorrect}}correct{{else}}incorrect{{/if}} {{/unless}} item-{{@index}} {{odd @index}}">
+        <div class="gmcq-item component-item {{#unless ../_isEnabled}}{{#if ../_canShowMarking}}{{#if _isCorrect}}correct{{else}}incorrect{{/if}}{{/if}}{{/unless}} item-{{@index}} {{odd @index}}">
             <input type="checkbox" id="{{../_id}}-{{@index}}" aria-labelledby="{{../_id}}-{{@index}}-aria"{{#unless ../_isEnabled}} disabled{{/unless}} aria-label="{{a11y_normalize text}} {{_graphic.alt}}"/>
             <label aria-hidden="true" id="{{../_id}}-{{@index}}-aria" for="{{../_id}}-{{@index}}" class="{{#unless ../_isEnabled}}disabled {{/unless}} component-item-color component-item-text-color component-item-border {{#if _isSelected}}selected{{/if}}">
 


### PR DESCRIPTION
Avoids adding correctness classes to items if `_canShowMarking` is false.

Please only merge once the new version of the framework has been released (v2.0.11).

Original issue: adaptlearning/adapt_framework#1046.