### PR TITLE
Updated feedback to show title independent of title/display title of the component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ guide the learner’s interaction with the component.
 **_feedback** (object): If the [**Tutor** extension](https://github.com/adaptlearning/adapt-contrib-tutor) is enabled, these various texts will be displayed depending on the submitted answer. **_feedback**
 contains values for three types of answers: **correct**, **_incorrect**, and **_partlyCorrect**. Some attributes are optional. If they are not supplied, the default that is noted below will be used.
 
+>**title** (string): Text that will be displayed as the feedback title.  
+
 >**correct** (string): Text that will be displayed when the submitted answer is correct.  
 
 >**_incorrect** (object): Texts that will be displayed when the submitted answer is incorrect. It contains values that are displayed under differing conditions: **final** and **notFinal**. 

--- a/example.json
+++ b/example.json
@@ -22,7 +22,7 @@
     "_items": [
         {
             "text": "This is option 1.",
-            "_shouldBeSelected":true,
+            "_shouldBeSelected": true,
             "_graphic": {
                 "alt": "Alt text for option 1",
                 "attribution": "Copyright © 2015",
@@ -42,6 +42,7 @@
         }
     ],
     "_feedback":{
+        "title": "Feedback title",
         "correct": "Congratulations, this is the correct feedback.",
         "_incorrect": {
             "notFinal": "",

--- a/properties.schema
+++ b/properties.schema
@@ -201,6 +201,16 @@
       "required": false,
       "title": "Feedback",
       "properties": {
+        "title": {
+          "type": "string",
+          "required": false,
+          "default": "",
+          "title": "Feedback Title",
+          "inputType": "Text",
+          "validators": [],
+          "help": "This text will display as the feedback title",
+          "translatable": true
+        },
         "correct": {
           "type": "string",
           "required": false,


### PR DESCRIPTION
Related to issue: adaptlearning/adapt_framework#1876
and PR: adaptlearning/adapt_framework#1954