### PR TITLE
issue/2799 Removed redundant behaviour

### DIFF
--- a/js/adapt-contrib-gmcq.js
+++ b/js/adapt-contrib-gmcq.js
@@ -1,8 +1,8 @@
-import Adapt from 'core/js/adapt';
+import components from 'core/js/components';
 import GmcqView from './GmcqView';
 import GmcqModel from './GmcqModel';
 
-export default Adapt.register('gmcq', {
+export default components.register('gmcq', {
   model: GmcqModel,
   view: GmcqView
 });

--- a/templates/gmcq.jsx
+++ b/templates/gmcq.jsx
@@ -1,4 +1,6 @@
 import Adapt from 'core/js/adapt';
+import a11y from 'core/js/a11y';
+import device from 'core/js/device';
 import React from 'react';
 import { templates, classes, compile } from 'core/js/reactHelpers';
 
@@ -23,7 +25,7 @@ export default function Gmcq(props) {
     onItemBlur
   } = props;
 
-  const screenSize = Adapt.device.screenSize;
+  const screenSize = device.screenSize;
 
   return (
     <div className='component__inner gmcq__inner'>
@@ -64,8 +66,8 @@ export default function Gmcq(props) {
               type={_isRadio ? 'radio' : 'checkbox'}
               disabled={!_isEnabled}
               aria-label={!_shouldShowMarking ?
-                `${Adapt.a11y.normalize(text)} ${_graphic?.alt || ''}` :
-                `${_shouldBeSelected ? ariaLabels.correct : ariaLabels.incorrect}, ${_isActive ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${Adapt.a11y.normalize(text)} ${_graphic?.alt || ''}`}
+                `${a11y.normalize(text)} ${_graphic?.alt || ''}` :
+                `${_shouldBeSelected ? ariaLabels.correct : ariaLabels.incorrect}, ${_isActive ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${a11y.normalize(text)} ${_graphic?.alt || ''}`}
               data-adapt-index={_index}
               onKeyPress={onKeyPress}
               onChange={onItemSelect}

--- a/templates/gmcq.jsx
+++ b/templates/gmcq.jsx
@@ -1,6 +1,6 @@
 import Adapt from 'core/js/adapt';
 import React from 'react';
-import { templates, classes, html, compile } from 'core/js/reactHelpers';
+import { templates, classes, compile } from 'core/js/reactHelpers';
 
 export default function Gmcq(props) {
   const ariaLabels = Adapt.course.get('_globals')._accessibility._ariaLabels;
@@ -11,7 +11,7 @@ export default function Gmcq(props) {
     _isInteractionComplete,
     _isCorrect,
     _isCorrectAnswerShown,
-    _canShowMarking,
+    _shouldShowMarking,
     _isRadio,
     _columns,
     displayTitle,
@@ -20,12 +20,10 @@ export default function Gmcq(props) {
     onKeyPress,
     onItemSelect,
     onItemFocus,
-    onItemBlur,
-    isInteractive
+    onItemBlur
   } = props;
 
   const screenSize = Adapt.device.screenSize;
-  const shouldShowMarking = !isInteractive() && _canShowMarking;
 
   return (
     <div className='component__inner gmcq__inner'>
@@ -50,8 +48,8 @@ export default function Gmcq(props) {
           <div
             className={classes([
               `gmcq-item item-${index}`,
-              (shouldShowMarking && _shouldBeSelected) ? 'is-correct' : null,
-              (shouldShowMarking && !_shouldBeSelected) ? 'is-incorrect' : null
+              (_shouldShowMarking && _shouldBeSelected) ? 'is-correct' : null,
+              (_shouldShowMarking && !_shouldBeSelected) ? 'is-incorrect' : null
             ])}
             style={(_columns && screenSize === 'large') ?
               { width: `${100 / _columns}%` } :
@@ -65,7 +63,7 @@ export default function Gmcq(props) {
               name={_isRadio ? `${_id}-item` : null}
               type={_isRadio ? 'radio' : 'checkbox'}
               disabled={!_isEnabled}
-              aria-label={!shouldShowMarking ?
+              aria-label={!_shouldShowMarking ?
                 `${Adapt.a11y.normalize(text)} ${_graphic?.alt || ''}` :
                 `${_shouldBeSelected ? ariaLabels.correct : ariaLabels.incorrect}, ${_isActive ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${Adapt.a11y.normalize(text)} ${_graphic?.alt || ''}`}
               data-adapt-index={_index}
@@ -118,8 +116,7 @@ export default function Gmcq(props) {
 
                 {text &&
                 <div className='gmcq-item__text'>
-                  <div className='gmcq-item__text-inner'>
-                    {html(compile(text))}
+                  <div className='gmcq-item__text-inner' dangerouslySetInnerHTML={{ __html: compile(text) }}>
                   </div>
                 </div>
                 }


### PR DESCRIPTION
requires https://github.com/adaptlearning/adapt-contrib-core/pull/84
part of https://github.com/adaptlearning/adapt_framework/issues/2799

### Changed
* Switched to `components.register` from `Adapt.register`
* Removed `html()` helper for `dangerouslySetInnerHtml`
* Direct import of `a11y` and `device`
* Use `_shouldShowMarking`