### PR TITLE
Issue/#147 - Introducing ariaQuestion field

### DIFF
--- a/example.json
+++ b/example.json
@@ -9,6 +9,7 @@
         "displayTitle": "GMCQ",
         "body": "Which of the following options would you consider to be correct?",
         "instruction": "",
+        "ariaQuestion": "",
         "_attempts": 1,
         "_shouldDisplayAttempts": false,
         "_hasItemScoring": false,

--- a/templates/gmcq.jsx
+++ b/templates/gmcq.jsx
@@ -19,6 +19,7 @@ export default function Gmcq(props) {
     displayTitle,
     body,
     instruction,
+    ariaQuestion,
     onKeyPress,
     onItemSelect,
     onItemFocus,
@@ -42,7 +43,8 @@ export default function Gmcq(props) {
           _columns && screenSize === 'large' && 'has-column-layout'
         ])}
         role={_isRadio ? 'radiogroup' : 'group'}
-        aria-labelledby={(displayTitle || body || instruction) && `${_id}-header`}
+        aria-labelledby={ariaQuestion ? null : (displayTitle || body || instruction) && `${_id}-header`}
+        aria-label={ariaQuestion || null}
       >
 
         {props._items.map(({ text, _index, _isActive, _shouldBeSelected, _graphic }, index) =>


### PR DESCRIPTION
ariaQuestion will allow screen-readers to focus just on the question when being presented question options instead of the screen-reader reading the title, body & instruction fields when focusing on the `group` or `radiogroup`. 

We never can predict where we might specifically script a question into the component header. Questions might be written at a higher level like the block title.