### PR TITLE
Fix: u-no-select class added to GMCQ item label (fixes #159)

### DIFF
--- a/templates/gmcq.jsx
+++ b/templates/gmcq.jsx
@@ -82,6 +82,7 @@ export default function Gmcq(props) {
               className={classes([
                 'gmcq-item__label',
                 'js-item-label',
+                'u-no-select',
                 !_isEnabled && 'is-disabled',
                 (_isCorrectAnswerShown ? _shouldBeSelected : _isActive) && 'is-selected'
               ])}


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes (#159)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
*  u-no-select class added to GMCQ item label (#159)

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Attempt to click and drag over text
2. Ensure text can't be highlighted and instead item is selected as expected

[//]: # (Mention any other dependencies)


