### PR TITLE
Fix: Reset item selection (fixes #186)

### DIFF
--- a/templates/gmcq.jsx
+++ b/templates/gmcq.jsx
@@ -67,7 +67,7 @@ export default function Gmcq(props) {
               name={_isRadio ? `${_id}-item` : null}
               type={_isRadio ? 'radio' : 'checkbox'}
               disabled={!_isEnabled}
-              defaultChecked={_isActive}
+              checked={_isActive}
               aria-label={!_shouldShowMarking ?
                 `${a11y.normalize(text)} ${_graphic?.alt || ''}` :
                 `${_shouldBeSelected ? ariaLabels.correct : ariaLabels.incorrect}, ${_isActive ? ariaLabels.selectedAnswer : ariaLabels.unselectedAnswer}. ${a11y.normalize(text)} ${_graphic?.alt || ''}`}


### PR DESCRIPTION
fixes [#186 ](https://github.com/adaptlearning/adapt-contrib-mcq/issues/186)

### Fix
* All items to be selected after reset