### PR TITLE
Fix: Use aria-disabled instead of disabled on input (fixes #183)

### DIFF
--- a/templates/gmcq.jsx
+++ b/templates/gmcq.jsx
@@ -73,7 +73,7 @@ export default function Gmcq(props) {
               id={`${_id}-${index}-input`}
               name={_isRadio ? `${_id}-item` : null}
               type={_isRadio ? 'radio' : 'checkbox'}
-              disabled={!_isEnabled}
+              aria-disabled={!_isEnabled}
               checked={_isActive}
               aria-label={!_shouldShowMarking ?
                 `${a11y.normalize(altText || text)} ${_graphic?.alt || ''}` :


### PR DESCRIPTION
fixes #183

### Fix
* Allow screen reader to read aria labels on items when items are disabled
